### PR TITLE
Fix clang warning.

### DIFF
--- a/libyasm/md5.c
+++ b/libyasm/md5.c
@@ -162,7 +162,7 @@ yasm_md5_final(unsigned char digest[16], yasm_md5_context *ctx)
         putu32(ctx->buf[1], digest + 4);
         putu32(ctx->buf[2], digest + 8);
         putu32(ctx->buf[3], digest + 12);
-        memset(ctx, 0, sizeof(ctx));    /* In case it's sensitive */
+        memset(ctx, 0, sizeof(*ctx));    /* In case it's sensitive */
 }
 
 #ifndef ASM_MD5


### PR DESCRIPTION
libyasm/md5.c:166:31: warning: argument to 'sizeof' in 'memset' call is the same expression as the destination; did you mean to dereference it? [-Wsizeof-pointer-memaccess]
        memset(ctx, 0, sizeof(ctx));    /\* In case it's sensitive */
               ~~~            ^~~
