### PR TITLE
Silence is golden: genperf emits too much stdout in success path

### DIFF
--- a/tools/genperf/perfect.c
+++ b/tools/genperf/perfect.c
@@ -671,8 +671,6 @@ static void hash_ab(
     sprintf(final->line[0], "  unsigned long rsl = (a ^ scramble[tab[b]]);\n");
   }
 
-  printf("success, found a perfect hash\n");
-
   free((void *)tabq);
   free((void *)tabh);
 }
@@ -901,8 +899,6 @@ void findhash(
       continue;                             /* two keys have same (a,b) pair */
     }
 
-    printf("found distinct (A,B) on attempt %ld\n", trysalt);
-
     /* Given distinct (A,B) for all keys, build a perfect hash */
     if (!perfect(*tabb, *tabh, tabq, *blen, *smax, scramble, nkeys, form))
     {
@@ -931,8 +927,6 @@ void findhash(
     *salt = trysalt;
     break;
   }
-
-  printf("built perfect hash table of size %ld\n", *blen);
 
   /* free working memory */
   free((void *)tabq);
@@ -1143,7 +1137,6 @@ hashform *form;                                           /* user directives */
 
   /* read in the list of keywords */
   getkeys(&keys, &nkeys, textroot, keyroot, form);
-  printf("Read in %ld keys\n",nkeys);
 
   /* find the hash */
   findhash(&tab, &alen, &blen, &salt, &final, 
@@ -1151,13 +1144,11 @@ hashform *form;                                           /* user directives */
 
   /* generate the phash.c file */
   make_c(tab, smax, blen, scramble, &final, form);
-  printf("Wrote phash.c\n");
 
   /* clean up memory sources */
   refree(textroot);
   refree(keyroot);
   free((void *)tab);
-  printf("Cleaned up\n");
 }
 
 


### PR DESCRIPTION
(this was motivated by the chromium build in which we get several invocation's worth of output cluttering up the console; redirecting stdout to /dev/null is difficult to do generically in this build system across all platforms)
