### PR TITLE
In the Mach-O writer, only warn on ignored flags if the new flags are different from the old flags.

### DIFF
--- a/modules/objfmts/macho/macho-objfmt.c
+++ b/modules/objfmts/macho/macho-objfmt.c
@@ -1497,9 +1497,13 @@ macho_objfmt_section_switch(yasm_object *object, yasm_valparamhead *valparams,
         msd->sectname = f_sectname;
         msd->flags = flags;
         yasm_section_set_align(retval, align, line);
-    } else if (flags_override)
-        yasm_warn_set(YASM_WARN_GENERAL,
-                      N_("section flags ignored on section redeclaration"));
+    } else if (flags_override) {
+        // align is the only value used from overrides.
+        if (yasm_section_get_align(retval) != align) {
+            yasm_warn_set(YASM_WARN_GENERAL,
+                          N_("section flags ignored on section redeclaration"));
+        }
+    }
     return retval;
 }
 


### PR DESCRIPTION
Fixes http://tortall.lighthouseapp.com/projects/78676-yasm/tickets/246

I looked at doing this in the other writers as well, but
- They tend to look at more than just `align`
- They already only warn if `!gasflags`
