### PR TITLE
Fix a couple warnings when building on win32

### DIFF
--- a/modules/arch/x86/x86id.c
+++ b/modules/arch/x86/x86id.c
@@ -643,7 +643,7 @@ x86_find_match(x86_id_insn *id_insn, yasm_insn_operand **ops,
         unsigned int misc_flags = info->misc_flags;
         unsigned int size;
         int mismatch = 0;
-        int i;
+        unsigned int i;
 
         /* Match CPU */
         if (mode_bits != 64 && (misc_flags & ONLY_64))

--- a/modules/objfmts/elf/elf.c
+++ b/modules/objfmts/elf/elf.c
@@ -98,7 +98,7 @@ elf_set_arch(yasm_arch *arch, yasm_symtab *symtab, int bits_pref)
                                                     elf_march->ssyms[i].name,
                                                     NULL, 0, 0);
             yasm_symrec_add_data(elf_ssyms[i], &elf_ssym_symrec_data,
-                                 &elf_march->ssyms[i]);
+                                 (void*)&elf_march->ssyms[i]);
         }
     }
 


### PR DESCRIPTION
...\modules\arch\x86\x86id.c(657) : warning C4018: '<' : signed/unsigned mismatch

and

...\modules\objfmts\elf\elf.c(102) : warning C4090: 'function' : different 'const' qualifiers
