### PR TITLE
Fix definition of pmulhrw

### DIFF
--- a/modules/arch/x86/gen_x86_insn.py
+++ b/modules/arch/x86/gen_x86_insn.py
@@ -8120,7 +8120,7 @@ add_insn("pfsub", "now3d", modifiers=[0x9A])
 add_insn("pfsubr", "now3d", modifiers=[0xAA])
 add_insn("pi2fd", "now3d", modifiers=[0x0D])
 add_insn("pi2fw", "now3d", modifiers=[0x0C], cpu=["Athlon", "3DNow"])
-add_insn("pmulhrwa", "now3d", modifiers=[0xB7])
+add_insn("pmulhrw", "now3d", modifiers=[0xB7])
 add_insn("pswapd", "now3d", modifiers=[0xBB], cpu=["Athlon", "3DNow"])
 
 #####################################################################


### PR DESCRIPTION
I am using yasm to do some testing of my disassembler (udis86) and trying out 3dnow instructions, I found that the "pmulhrw" instruction was not supported. Turns out it was defined as "pmulhrwa". Unless I am missing something, this looks like a typo; so here's a quick fix for it.
