### PR TITLE
Use a larger hash table size

### DIFF
--- a/modules/preprocs/nasm/nasm-pp.c
+++ b/modules/preprocs/nasm/nasm-pp.c
@@ -366,7 +366,7 @@ static ListGen *list;
  * FIXME: We should *really* be able to configure this at run time,
  * or even have the hash table automatically expanding when necessary.
  */
-#define NHASH 31
+#define NHASH 4096
 
 /*
  * The current set of multi-line macros we have defined.


### PR DESCRIPTION
Increases compilation speed of files with a large number of macros by
around 20x.
