### PR TITLE
Avoid shadowing warning when building with VS2015

### DIFF
--- a/tools/re2c/code.c
+++ b/tools/re2c/code.c
@@ -936,12 +936,12 @@ void DFA_emit(DFA *d, FILE *o){
 	oline++;
 	useLabel(label);
     } else {
-	int i;
+	int j;
 	fputs("\tswitch(YYGETSTATE()) {\n", o);
 	fputs("\t\tcase -1: goto yy0;\n", o);
 
-	for (i=0; i<maxFillIndexes; ++i)
-	    fprintf(o, "\t\tcase %u: goto yyFillLabel%u;\n", i, i);
+	for (j=0; j<maxFillIndexes; ++j)
+	    fprintf(o, "\t\tcase %d: goto yyFillLabel%d;\n", j, j);
 
 	fputs("\t\tdefault: /* abort() */;\n", o);
 	fputs("\t}\n", o);


### PR DESCRIPTION
d:\src\cr2\src\third_party\yasm\source\patched-yasm\tools\re2c\code.c(939): error C2220: warning treated as error - no 'object' file generated
d:\src\cr2\src\third_party\yasm\source\patched-yasm\tools\re2c\code.c(939): warning C4456: declaration of 'i' hides previous local declaration
d:\src\cr2\src\third_party\yasm\source\patched-yasm\tools\re2c\code.c(764): note: see declaration of 'i'