### PR TITLE
fixing an argument parsing bug in ytasm

### DIFF
--- a/frontends/tasm/tasm-options.c
+++ b/frontends/tasm/tasm-options.c
@@ -65,15 +65,18 @@ parse_cmdline(int argc, char **argv, opt_option *options, size_t nopts,
 
                     param = &argv[0][1+len];
                     if (options[i].takes_param) {
-                        if (param[0] == '\0') {
+                        if (param[0] != '\0') {
+                            /* do nothing */
+                        } else if (argc > 1) {
+                            param = argv[1];
+                            argc--;
+                            argv++;
+                        } else {
                             print_error(
-                                _("option `-%c' needs an argument!"),
+                                _("option `-%s' needs an argument!"),
                                 options[i].opt);
                             errors++;
                             goto fail;
-                        } else {
-                            argc--;
-                            argv++;
                         }
                     } else
                         param = NULL;


### PR DESCRIPTION
Taken from a Debian patch.
More information can be found at
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=716639
http://anonscm.debian.org/viewvc/sam-hocevar/pkg-misc/unstable/yasm/debian/patches/100_ytasm_parsing_error.diff?view=log