### PR TITLE
Only print 'warnings treated as errors' if there were warnings

### DIFF
--- a/libyasm/errwarn.c
+++ b/libyasm/errwarn.c
@@ -492,14 +492,6 @@ yasm_errwarns_output_all(yasm_errwarns *errwarns, yasm_linemap *lm,
     const char *filename, *xref_filename;
     unsigned long line, xref_line;
 
-    /* If we're treating warnings as errors, tell the user about it. */
-    if (warning_as_error && warning_as_error != 2) {
-        print_error("", 0,
-                    yasm_gettext_hook(N_("warnings being treated as errors")),
-                    NULL, 0, NULL);
-        warning_as_error = 2;
-    }
-
     /* Output error/warnings. */
     SLIST_FOREACH(we, &errwarns->errwarns, link) {
         /* Output error/warning */
@@ -514,7 +506,17 @@ yasm_errwarns_output_all(yasm_errwarns *errwarns, yasm_linemap *lm,
             print_error(filename, line, we->msg, xref_filename, xref_line,
                         we->xrefmsg);
         else
+        {
             print_warning(filename, line, we->msg);
+
+            /* If we're treating warnings as errors, tell the user about it. */
+            if (warning_as_error && warning_as_error != 2) {
+                const char *msg =
+                    yasm_gettext_hook(N_("warnings being treated as errors"));
+                print_error(filename, line, msg, NULL, 0, NULL);
+                warning_as_error = 2;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Using -Werror makes yasm print a "error: warnings treated as errors" error message for each invocation, which is a bit annoying, it only needs to be printed if there were any warnings to treat as errors. I thought it looked weird without that file:line header too, so this prints the warnings-as-errors message with the file and line of the first warning generated.
