### PR TITLE
avoid 'return value of ftruncate ignored' warnings

### DIFF
--- a/modules/objfmts/bin/bin-objfmt.c
+++ b/modules/objfmts/bin/bin-objfmt.c
@@ -2040,7 +2040,8 @@ dosexe_objfmt_output(yasm_object *object, FILE *f, /*@unused@*/ int all_syms,
     bss_size = tot_size - size;
 #ifdef HAVE_FTRUNCATE
     if (size != tot_size)
-        ftruncate(fileno(f), EXE_HEADER_SIZE + size);
+        if (ftruncate(fileno(f), EXE_HEADER_SIZE + size))
+            ; /* No-op. Report an error? */
 #endif
     fseek(f, 0, SEEK_SET);
 


### PR DESCRIPTION
This tiny patch avoids 'return value of ftruncate ignored' warnings, which is useful if ftruncate was declared with the warn_unused_result GCC attribute (which seems to be the case sometimes).
