### PR TITLE
Draft: Add Drone CI build scripts.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,13 @@
+build:
+  image: fracting/msys32
+  pull: true
+  shell: $$platform
+  commands:
+    - export platform=$$platform
+    - ./ci-build.sh
+
+matrix:
+  platform:
+    - bash
+    - msys32
+    - mingw32

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+if test "$platform" = "bash"; then
+    echo "Building on Ubuntu Linux x86_64"
+    sudo apt-get install build-essential automake
+elif test "$platform" = "msys32"; then
+    echo "Building on Msys2 i686"
+elif test "$platform" = "mingw32"; then
+    echo "Building on MinGW-w64 i686"
+    pacman --sync --noconfirm --noprogressbar mingw-w64-i686-gettext
+else
+    echo "unknown environment!"
+    exit 1
+fi
+
+./autogen.sh
+make
+make check || echo WARNING: make check failed


### PR DESCRIPTION
Hi folks,

I'm the creator of Tea CI and a contributor of MSYS2 project.

Tea CI is a fork of continuous integration server called Drone CI with additional support for Win32 application using Wine.
It has been used by MSYS2 project for some time, examples here:
https://tea-ci.org/Alexpux/MINGW-packages

I created a set of CI build scripts for yasm project. With the nice `matrix` feature of our CI server, our CI script could build yasm for three platforms: Ubuntu Linux 64 bit, Msys2 32bit, and MinGW-w64 32bit.

The main purpose of continuous integration is to make sure every patch compiles and pass the test suite, however, currently there is three test case failed, failed in the same way in all the platforms:

https://tea-ci.org/fracting/yasm/8

```
FAIL: modules/arch/x86/tests/x86_test.sh
FAIL: modules/arch/lc3b/tests/lc3b_test.sh
FAIL: libyasm/tests/libyasm_test.sh
```

```
# TOTAL: 44
# PASS:  41
# SKIP:  0
# XFAIL: 0
# FAIL:  3
# XPASS: 0
# ERROR: 0
```

I ignored the test failure for now to make sure the CI builds pass. If anyone could give some help on test failure that would be great appreciated.

The goal is to enable all test suites on all platforms, so once there is something broken, we can compare results from different platforms. 

I hope this script could be useful for yasm team, and once it is accepted, it would be benefit the Wine project and the MSYS2 project as well.

Could you consider the proposal, and maybe register tea-ci.org using your github account, so the CI build could be triggered by git pushes and pull requests?

Once this is accepted, we can add more features, like, irc notifications, nightly build binaries automatic upload, etc.

Looking forward to your comments, thanks!
