### PR TITLE
Fix compiling error when using vsyasm with VS2013 or newer version on Win10

### DIFF
--- a/frontends/vsyasm/vsyasm.c
+++ b/frontends/vsyasm/vsyasm.c
@@ -912,6 +912,13 @@ opt_objfmt_handler(/*@unused@*/ char *cmd, char *param, /*@unused@*/ int extra)
 {
     size_t i;
     assert(param != NULL);
+#if 1
+    if (!stricmp(param, "win32")) {
+        param = "win32";
+    } else if (!stricmp(param, "win64") || !stricmp(param, "x64")) {
+        param = "win64";
+    }
+#endif
     cur_objfmt_module = yasm_load_objfmt(param);
     if (!cur_objfmt_module) {
         if (!strcmp("help", param)) {


### PR DESCRIPTION
On my desktop with Visual Studio 2013 and Windows 10, `vsyasm 1.3.0` could not be used.
It will report errors like:
```
vsyasm: FATAL: unrecognized object format `Win32' 
vsyasm: FATAL: unrecognized object format `x64' 
```
It can be fixxed by change the input parameters into `win32` and `win64` to solve the problem.