### PR TITLE
fix memory errors when using gas processor with coff object output.

### DIFF
--- a/modules/arch/x86/gen_x86_insn.py
+++ b/modules/arch/x86/gen_x86_insn.py
@@ -7909,15 +7909,17 @@ add_insn("xsaveopt64", "xsaveopt64", modifiers=[6, 0x0F, 0xAE],
 #####################################################################
 # Intel MOVBE instruction
 #####################################################################
-for sz in (16, 32, 64):
+for sfx, sz in zip("wlq", [16, 32, 64]):
     add_group("movbe",
         cpu=["MOVBE"],
+        suffix=sfx,
         opersize=sz,
         opcode=[0x0F, 0x38, 0xF0],
         operands=[Operand(type="Reg", size=sz, dest="Spare"),
                   Operand(type="Mem", size=sz, relaxed=True, dest="EA")])
     add_group("movbe",
         cpu=["MOVBE"],
+        suffix=sfx,
         opersize=sz,
         opcode=[0x0F, 0x38, 0xF1],
         operands=[Operand(type="Mem", size=sz, relaxed=True, dest="EA"),

--- a/modules/objfmts/coff/coff-objfmt.c
+++ b/modules/objfmts/coff/coff-objfmt.c
@@ -290,6 +290,7 @@ coff_common_create(yasm_object *object)
     objfmt_coff->done_prolog = 0;
     objfmt_coff->unwind = NULL;
     objfmt_coff->ssym_imagebase = NULL;
+    objfmt_coff->def_sym = NULL;
 
     return objfmt_coff;
 }


### PR DESCRIPTION
The coff objfmt object was not initializing def_sym. This is used by the gas parser causing it to write to uninitialized memory.
This fixes random crashes that occur when compiling with gas on windows.