### PR TITLE
Fix info.stab / info.stabstr typo in stabs-dbgfmt.c

### DIFF
--- a/modules/dbgfmts/stabs/stabs-dbgfmt.c
+++ b/modules/dbgfmts/stabs/stabs-dbgfmt.c
@@ -355,7 +355,7 @@ stabs_dbgfmt_generate(yasm_object *object, yasm_linemap *linemap,
             yasm_error_set(YASM_ERROR_GENERAL,
                 N_("stabs debugging conflicts with user-defined section .stabstr"));
             yasm_errwarn_propagate(errwarns,
-                                   yasm_section_bcs_first(info.stab)->line);
+                                   yasm_section_bcs_first(info.stabstr)->line);
         } else {
             yasm_warn_set(YASM_WARN_GENERAL,
                 N_("stabs debugging overrides empty section .stabstr"));


### PR DESCRIPTION
fixes issue #88. typo was introduced by commit 4c33af4 back in 2006.