### PR TITLE
enable AES on westmere

### DIFF
--- a/modules/arch/x86/gen_x86_insn.py
+++ b/modules/arch/x86/gen_x86_insn.py
@@ -37,7 +37,7 @@ ordered_cpus = [
 ordered_cpu_features = [
     "FPU", "Cyrix", "AMD", "MMX", "3DNow", "SMM", "SSE", "SSE2",
     "SSE3", "SVM", "PadLock", "SSSE3", "SSE41", "SSE42", "SSE4a", "SSE5",
-    "AVX", "FMA", "AES", "CLMUL", "MOVBE", "XOP", "FMA4", "F16C",
+    "AES", "AVX", "FMA", "CLMUL", "MOVBE", "XOP", "FMA4", "F16C",
     "FSGSBASE", "RDRAND", "XSAVEOPT", "EPTVPID", "SMX", "AVX2", "BMI1",
     "BMI2", "INVPCID", "LZCNT", "TBM", "TSX", "SHA", "SMAP", "RDSEED", "ADX",
     "PRFCHW"]


### PR DESCRIPTION
Prior to this change: cpu_lcd(['AVX'], ['AVX','AES']) == ['AVX'],
causing AES instructions to be treated as unsupported when "cpu
WESTMERE" is used, or even "cpu WESTMERE AES".

Fixed by reordering ordered_cpu_features such that now,
cpu_lcd(['AVX'], ['AVX','AES']) == ['AES']. I don't know if there are
CPUs this would not be correct for, but this is the value that's
consistent with all extant CPU definitions (the only CPU defined
with AVX xor AES is westmere).