### PR TITLE
Allocator mismatch

### DIFF
--- a/libyasm/bitvect.c
+++ b/libyasm/bitvect.c
@@ -457,7 +457,7 @@ void BitVector_Destroy_List(listptr list, N_int count)      /* free list     */
         {
             BitVector_Destroy(*slot++);
         }
-        free((voidptr) list);
+        yasm_xfree((voidptr) list);
     }
 }
 
@@ -496,7 +496,7 @@ listptr BitVector_Create_List(N_int bits, boolean clear, N_int count)
 
     if (count > 0)
     {
-        list = (listptr) malloc(sizeof(wordptr) * count);
+        list = (listptr) yasm_xmalloc(sizeof(wordptr) * count);
         if (list != NULL)
         {
             slot = list;

--- a/libyasm/file.c
+++ b/libyasm/file.c
@@ -473,7 +473,7 @@ yasm__createpath_common(const char *path, int win)
     size_t len, lth;
 
     lth = len = strlen(path);
-    ts = tp = (char *) malloc(len + 1);
+    ts = tp = (char *) yasm_xmalloc(len + 1);
     pe = pp + len;
     while (pe > pp) {
         if ((win && *pe == '\\') || *pe == '/')
@@ -523,7 +523,7 @@ yasm__createpath_common(const char *path, int win)
         }
         *tp++ = *pp++;
     }
-    free(ts);
+    yasm_xfree(ts);
     return lth;
 }
 

--- a/libyasm/tests/bitvect_test.c
+++ b/libyasm/tests/bitvect_test.c
@@ -109,7 +109,7 @@ num_check(Val *val)
         strcat(result_msg, ": ");
         strcat(result_msg, (char *)ascii);
     }
-    free(result);
+    yasm_xfree(result);
     
     return ret;
 }

--- a/libyasm/tests/floatnum_test.c
+++ b/libyasm/tests/floatnum_test.c
@@ -177,7 +177,7 @@ new_check_flt(Init_Entry *val)
     for (i=1;i<MANT_BYTES;i++)      /* don't compare first byte */
         if (mantissa[i] != val->mantissa[i])
             result = 1;
-    free(mantissa);
+    yasm_xfree(mantissa);
     if (result) {
         strcat(result_msg, "mantissa");
         return 1;
@@ -231,7 +231,7 @@ test_new_normalized_edgecase(void)
 static void
 get_family_setup(void)
 {
-    flt = malloc(sizeof(yasm_floatnum));
+    flt = yasm_xmalloc(sizeof(yasm_floatnum));
     flt->mantissa = BitVector_Create(MANT_BITS, TRUE);
 }
 
@@ -239,7 +239,7 @@ static void
 get_family_teardown(void)
 {
     BitVector_Destroy(flt->mantissa);
-    free(flt);
+    yasm_xfree(flt);
 }
 
 static void

--- a/modules/preprocs/nasm/nasm-pp.c
+++ b/modules/preprocs/nasm/nasm-pp.c
@@ -705,7 +705,7 @@ check_tasm_directive(char *line)
             "%%define %s %%1\n";
         char **data;
 
-        data = malloc(2*sizeof(char*));
+        data = nasm_malloc(2*sizeof(char*));
         oldline = line;
         line = nasm_malloc(strlen(irp_format) - 2 + len2 + 1);
         sprintf(line,irp_format,q);
@@ -804,7 +804,7 @@ check_tasm_directive(char *line)
         oldline = line;
         line = nasm_malloc(5 + 1 + len + 1);
         sprintf(line, "struc %s", p);
-        struc = malloc(sizeof(*struc));
+        struc = nasm_malloc(sizeof(*struc));
         struc->name = nasm_strdup(p);
         struc->fields = NULL;
         struc->lastField = NULL;
@@ -1079,7 +1079,7 @@ prepreproc(char *line)
         d = strchr(c+1, '\n');
         if (d)
             *d = '\0';
-        l = malloc(sizeof(*l));
+        l = nasm_malloc(sizeof(*l));
         l -> first = tokenise(c+1);
         l -> finishes = NULL;
         l -> next = *lp;

--- a/tools/genperf/genperf.c
+++ b/tools/genperf/genperf.c
@@ -242,8 +242,8 @@ perfect_gen(FILE *out, const char *lookup_function_name,
     fprintf(out, "}\n");
     fprintf(out, "\n");
 
-    free(tab);
-    free(tabh);
+    yasm_xfree(tab);
+    yasm_xfree(tabh);
 }
 
 int

--- a/tools/genperf/perfect.c
+++ b/tools/genperf/perfect.c
@@ -635,7 +635,7 @@ static void hash_ab(
     else
     {
       /* try with 2*smax */
-      free((void *)tabh);
+      yasm_xfree((void *)tabh);
       *smax = *smax * 2;
       scrambleinit(scramble, *smax);
       tabh = (hstuff *)yasm_xmalloc(sizeof(hstuff)*(form->perfect == MINIMAL_HP ?
@@ -671,8 +671,8 @@ static void hash_ab(
     sprintf(final->line[0], "  unsigned long rsl = (a ^ scramble[tab[b]]);\n");
   }
 
-  free((void *)tabq);
-  free((void *)tabh);
+  yasm_xfree((void *)tabq);
+  yasm_xfree((void *)tabh);
 }
 
 
@@ -883,8 +883,8 @@ void findhash(
         else if (*blen < *smax)
         {
           *blen *= 2;
-          free(tabq);
-          free(*tabb);
+          yasm_xfree(tabq);
+          yasm_xfree(*tabb);
           *tabb  = (bstuff *)yasm_xmalloc((size_t)(sizeof(bstuff)*(*blen)));
           tabq  = (qstuff *)yasm_xmalloc((size_t)(sizeof(qstuff)*(*blen+1)));
         }
@@ -909,8 +909,8 @@ void findhash(
         if (*blen < *smax)
         {
           *blen *= 2;
-          free(*tabb);
-          free(tabq);
+          yasm_xfree(*tabb);
+          yasm_xfree(tabq);
           *tabb  = (bstuff *)yasm_xmalloc((size_t)(sizeof(bstuff)*(*blen)));
           tabq  = (qstuff *)yasm_xmalloc((size_t)(sizeof(qstuff)*(*blen+1)));
           --trysalt;               /* we know this salt got distinct (A,B) */
@@ -930,7 +930,7 @@ void findhash(
   }
 
   /* free working memory */
-  free((void *)tabq);
+  yasm_xfree((void *)tabq);
 }
 
 #if 0
@@ -1149,7 +1149,7 @@ hashform *form;                                           /* user directives */
   /* clean up memory sources */
   refree(textroot);
   refree(keyroot);
-  free((void *)tab);
+  yasm_xfree((void *)tab);
 }
 
 


### PR DESCRIPTION
I discovered some issues regarding mixed usage of `malloc` and `yasm_xmalloc` when implementing a custom allocator.

I replaced all usages of `malloc` in `libyasm` with `yasm_xmalloc` and the same for `free` -> `yasm_xfree`. I don't know how to run the tests so I'm not sure they will compile (using CMake on Windows).

In the nasm code there is a similar issue but it looks like those `malloc` calls could have been on purpose. I replaced them anyway because I want to only use my custom allocator.