### PR TITLE
allow sha256rnds2 to have memory as 2nd operand

### DIFF
--- a/modules/arch/x86/gen_x86_insn.py
+++ b/modules/arch/x86/gen_x86_insn.py
@@ -8096,7 +8096,7 @@ add_group("intel_SHA256RNDS2",
 	cpu=["SHA"],
 	opcode=[0x0F, 0x38, 0xCB],
 	operands=[Operand(type="SIMDReg", size=128, dest="Spare"),
-		Operand(type="SIMDReg", size=128, dest="EA")])
+		Operand(type="SIMDRM", size=128, dest="EA")])
 
 add_insn("SHA1MSG1", "intel_SHA1MSG1")
 add_insn("SHA1MSG2", "intel_SHA1MSG2")


### PR DESCRIPTION
this permits to process e.g.
sha256rnds2 xmm7, oword [esp]
which results in 0f38cb3c24