### PR TITLE
fix misleading whitespace

### DIFF
--- a/tools/re2c/code.c
+++ b/tools/re2c/code.c
@@ -461,8 +461,8 @@ Go_genSwitch(Go *g, FILE *o, State *from, State *next, int *readCh){
 	    if(g->span[i].to != def)
 		*(t++) = &g->span[i];
 
-	    if (dFlag)
-		fputs("\tYYDEBUG(-1, yych);\n", o);
+	if (dFlag)
+	    fputs("\tYYDEBUG(-1, yych);\n", o);
 
 #if 0
 	if (*readCh) {


### PR DESCRIPTION
From GCC:
```
modules/objfmts/bin/bin-objfmt.c: In function 'bin_objfmt_value_finalize':
modules/objfmts/bin/bin-objfmt.c:1006:13: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
             if (term != value->abs->numterms-1) /* if it wasn't last.. */
             ^~
modules/objfmts/bin/bin-objfmt.c:1013:17: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'
                 value->abs->numterms--;
                 ^~~~~
```