### PR TITLE
libyasm/section.c: support gas .private_extern directive

### DIFF
--- a/libyasm/section.c
+++ b/libyasm/section.c
@@ -123,6 +123,23 @@ dir_global(yasm_object *object, yasm_valparamhead *valparams,
 }
 
 static void
+dir_privextern(yasm_object *object, yasm_valparamhead *valparams,
+               yasm_valparamhead *objext_valparams, unsigned long line)
+{
+    yasm_valparamhead vps;
+
+    yasm_vps_initialize(&vps);
+    if (!objext_valparams) {
+        yasm_valparam *vp;
+
+        vp = yasm_vp_create_id(NULL, strdup("private_extern"), '$');
+        yasm_vps_append(&vps, vp);
+        objext_valparams = &vps;
+    }
+    dir_global(object, valparams, objext_valparams, line);
+}
+
+static void
 dir_common(yasm_object *object, yasm_valparamhead *valparams,
            yasm_valparamhead *objext_valparams, unsigned long line)
 {
@@ -164,6 +181,7 @@ static const yasm_directive object_directives[] = {
     { ".extern",        "gas",  dir_extern,     YASM_DIR_ID_REQUIRED },
     { ".global",        "gas",  dir_global,     YASM_DIR_ID_REQUIRED },
     { ".globl",         "gas",  dir_global,     YASM_DIR_ID_REQUIRED },
+    { ".private_extern","gas",  dir_privextern, YASM_DIR_ID_REQUIRED },
     { "extern",         "nasm", dir_extern,     YASM_DIR_ID_REQUIRED },
     { "global",         "nasm", dir_global,     YASM_DIR_ID_REQUIRED },
     { "common",         "nasm", dir_common,     YASM_DIR_ID_REQUIRED },


### PR DESCRIPTION
Support for "private_extern" was previously added for nasm mode via
a declaration like so:

    global foo:private_extern
    foo:
             ; codes

However, that same code in gas format looks like this:

    .private_extern foo
    foo:
             # codes

Add support for the gas version of "private_extern" syntax by
supporting a new gas `.private_extern` directive that actually
has exactly the same semantics as the nasm `global ...:private_extern`
directive.

This fully closes issue #57.

Signed-off-by: Kyle J. McKay <mackyle@gmail.com>