### PR TITLE
add utf encoding string operations

### DIFF
--- a/libyasm/bc-data.c
+++ b/libyasm/bc-data.c
@@ -456,6 +456,141 @@ yasm_dv_create_expr(yasm_expr *e)
     return retval;
 }
 
+static int
+next_codepoint(/*@out@*/unsigned int *cpt, unsigned char* u8, size_t len) {
+    char need = 0, seen = 1, low = 0x80, hig = 0xBF;
+    if (len <= 0) return 0;
+    if (0x00 <= *u8 && *u8 <= 0x7F) {
+        *cpt = *u8;
+        return seen;
+    }
+    if (0xC2 <= *u8 && *u8 <= 0xDF) {
+        need = 1;
+        *cpt = *u8 & 0x1F;
+    }
+    if (0xE0 <= *u8 && *u8 <= 0xEF) {
+        need = 2;
+        if (*u8 == 0xE0)
+            low = 0xA0;
+        if (*u8 == 0xED)
+            hig = 0x9F;
+        *cpt = *u8 & 0xF;
+    }
+    if (0xF0 <= *u8 && *u8 <= 0xEF) {
+        need = 3;
+        if (*u8 == 0xF0)
+            low = 0x90;
+        if (*u8 == 0xF4)
+            hig = 0x8F;
+        *cpt = *u8 & 0x7;
+    }
+    u8++; len--;
+    while (len > 0 && need > 0) {
+        if (0x80 <= *u8 && *u8 <= 0xBF) {
+            *cpt = (*cpt << 6) | (*u8 & 0x3F);
+            u8++; len--;
+            need--; seen++;
+        } else {
+            return -seen;
+        }
+    }
+    return seen;
+}
+
+static int
+utf16enc(/*@out@*/unsigned char* u16, unsigned int cpt, char be) {
+    if (cpt <= 0xFFFF) {
+        for (int i=0; i<2; i++) {
+            u16[be?i:1-i] = cpt & 0xFF;
+            cpt >>= 8;
+        }
+        return 2;
+    }
+    if (cpt <= 0x100FFFF) {
+        // 000u uuuu xxxx xxxx xxxx xxxx
+        // wwww = uuuuu - 1
+        unsigned int u1 = ((cpt >> 16) & 0x1FF) - 1,
+                     u2 = cpt & 0xFFFF;
+        // 1101 10ww wwxx xxxx
+        u1 = 0xD800 | (u1 << 6) | (u2 >> 10);
+        for (int i=0; i<2; i++) {
+            u16[be?i:1-i] = u1 & 0xFF;
+            u1 >>= 8;
+        }
+        u16 += 2;
+        // 1101 11xx xxxx xxxx
+        u2 = 0xDC00 | (u2 & 0x3FF);
+        for (int i=0; i<2; i++) {
+            u16[be?i:1-i] = u2 & 0xFF;
+            u2 >>= 8;
+        }
+        return 8;
+    }
+    return -1;
+}
+
+static int
+utf32enc(/*@out@*/unsigned char* u32, unsigned int cpt, char be) {
+    for (int i=0; i<4; i++) {
+        u32[be?3-i:i] = cpt & 0xFF;
+        cpt >>= 8;
+    }
+    return 4;
+}
+
+yasm_dataval *
+yasm_dv_create_string(char *contents, size_t len, yasm_utfenc enc) {
+    unsigned char *raw = (unsigned char*)contents;
+    unsigned char *buf = raw;
+    unsigned int bufn = len;
+    int (*utfenc)(unsigned char*, unsigned int, char);
+    char be;
+
+    // logic borrowed from https://encoding.spec.whatwg.org/#utf-8-decoder
+    // and http://www.unicode.org/versions/Unicode13.0.0/ch03.pdf#G7404
+    switch (enc) {
+        case UTF16BE:
+        case UTF16LE:
+            bufn = len*2;
+            utfenc = utf16enc;
+            be = enc == UTF16BE;
+            break;
+
+        case UTF32BE:
+        case UTF32LE:
+            bufn = len*4;
+            utfenc = utf32enc;
+            be = enc == UTF32BE;
+            break;
+
+        case UTF8:
+        default:
+            break;
+    }
+
+    if (bufn != len) {
+        unsigned int cpt;
+        buf = yasm_xmalloc(bufn);
+        for (int i=0,j=0; i<len;) {
+            if (j > bufn)
+                goto encodeerr;
+            int read = next_codepoint(&cpt, raw+i, len-i);
+            if (read <= 0)
+                goto encodeerr;
+            i += read;
+            int wrtn = utfenc(buf+j, cpt, be);
+            if (wrtn <= 0)
+                goto encodeerr;
+            j += wrtn;
+        }
+    }
+    return yasm_dv_create_raw(buf, bufn);
+
+encodeerr:
+    yasm_xfree(buf);
+    return NULL;
+}
+
 yasm_dataval *
 yasm_dv_create_raw(unsigned char *contents, unsigned long len)
 {

--- a/libyasm/bytecode.h
+++ b/libyasm/bytecode.h
@@ -551,10 +551,11 @@ yasm_dataval *yasm_dv_create_expr(/*@keep@*/ yasm_expr *expn);
 /** Create a new data value from a string.
  * \param contents      string (may contain NULs)
  * \param len           length of string
+ * \param enc           utf encoding of string
  * \return Newly allocated data value.
  */
 YASM_LIB_DECL
-yasm_dataval *yasm_dv_create_string(/*@keep@*/ char *contents, size_t len);
+yasm_dataval *yasm_dv_create_string(/*@keep@*/ char *contents, size_t len, yasm_utfenc enc);
 
 /** Create a new data value from raw bytes data.
  * \param contents      raw data (may contain NULs)
@@ -570,11 +571,6 @@ yasm_dataval *yasm_dv_create_raw(/*@keep@*/ unsigned char *contents,
  */
 YASM_LIB_DECL
 yasm_dataval *yasm_dv_create_reserve(void);
-
-#ifndef YASM_DOXYGEN
-#define yasm_dv_create_string(s, l) yasm_dv_create_raw((unsigned char *)(s), \
-                                                       (unsigned long)(l))
-#endif
 
 /** Get the underlying value of a data value.
  * \param dv    data value

--- a/libyasm/coretype.h
+++ b/libyasm/coretype.h
@@ -214,6 +214,9 @@ typedef struct yasm_effaddr yasm_effaddr;
  */
 typedef struct yasm_insn yasm_insn;
 
+/** Possible utf encodings for a string */
+typedef enum yasm_utfenc { UTF8 = 0, UTF16LE, UTF32LE, UTF16BE, UTF32BE } yasm_utfenc;
+
 /** Expression operators usable in #yasm_expr expressions. */
 typedef enum yasm_expr_op {
     YASM_EXPR_IDENT,    /**< No operation, just a value. */

--- a/modules/dbgfmts/codeview/cv-symline.c
+++ b/modules/dbgfmts/codeview/cv-symline.c
@@ -407,7 +407,8 @@ cv_append_str(yasm_section *sect, const char *str)
 
     yasm_dvs_initialize(&dvs);
     yasm_dvs_append(&dvs, yasm_dv_create_string(yasm__xstrdup(str),
-                                                strlen(str)));
+                                                strlen(str),
+                                                UTF8));
     bc = yasm_bc_create_data(&dvs, 1, 1, NULL, 0);
     yasm_bc_finalize(bc, yasm_cv__append_bc(sect, bc));
     yasm_bc_calc_len(bc, NULL, NULL);

--- a/modules/dbgfmts/dwarf2/dwarf2-info.c
+++ b/modules/dbgfmts/dwarf2/dwarf2-info.c
@@ -250,7 +250,8 @@ dwarf2_append_str(yasm_section *sect, const char *str)
 
     yasm_dvs_initialize(&dvs);
     yasm_dvs_append(&dvs, yasm_dv_create_string(yasm__xstrdup(str),
-                                                strlen(str)));
+                                                strlen(str),
+                                                UTF8));
     bc = yasm_bc_create_data(&dvs, 1, 1, NULL, 0);
     yasm_bc_finalize(bc, yasm_dwarf2__append_bc(sect, bc));
     yasm_bc_calc_len(bc, NULL, NULL);

--- a/modules/objfmts/coff/coff-objfmt.c
+++ b/modules/objfmts/coff/coff-objfmt.c
@@ -1662,10 +1662,12 @@ dir_export(yasm_object *object, yasm_valparamhead *valparams,
     /* Add text as data bytecode */
     yasm_dvs_initialize(&dvs);
     yasm_dvs_append(&dvs, yasm_dv_create_string(yasm__xstrdup("-export:"),
-                                                strlen("-export:")));
+                                                strlen("-export:"),
+                                                UTF8));
     yasm_dvs_append(&dvs, yasm_dv_create_string(yasm__xstrdup(symname),
-                                                strlen(symname)));
-    yasm_dvs_append(&dvs, yasm_dv_create_string(yasm__xstrdup(" "), 1));
+                                                strlen(symname),
+                                                UTF8));
+    yasm_dvs_append(&dvs, yasm_dv_create_string(yasm__xstrdup(" "), 1, UTF8));
     yasm_section_bcs_append(sect, yasm_bc_create_data(&dvs, 1, 0, NULL, line));
 }
 
@@ -1815,7 +1817,7 @@ dir_ident(yasm_object *object, yasm_valparamhead *valparams,
             return;
         }
         yasm_dvs_append(&dvs,
-                        yasm_dv_create_string(yasm__xstrdup(s), strlen(s)));
+                        yasm_dv_create_string(yasm__xstrdup(s), strlen(s), UTF8));
     } while ((vp = yasm_vps_next(vp)));
 
     yasm_section_bcs_append(comment,

--- a/modules/objfmts/elf/elf-objfmt.c
+++ b/modules/objfmts/elf/elf-objfmt.c
@@ -1270,7 +1270,7 @@ dir_ident(yasm_object *object, yasm_valparamhead *valparams,
             return;
         }
         yasm_dvs_append(&dvs,
-                        yasm_dv_create_string(yasm__xstrdup(s), strlen(s)));
+                        yasm_dv_create_string(yasm__xstrdup(s), strlen(s), UTF8));
     } while ((vp = yasm_vps_next(vp)));
 
     yasm_section_bcs_append(comment,

--- a/modules/parsers/gas/gas-parse.c
+++ b/modules/parsers/gas/gas-parse.c
@@ -1097,7 +1097,7 @@ parse_strvals(yasm_parser_gas *parser_gas, yasm_datavalhead *dvs)
             yasm_dvs_initialize(dvs);
             return 0;
         }
-        dv = yasm_dv_create_string(STRING_val.contents, STRING_val.len);
+        dv = yasm_dv_create_string(STRING_val.contents, STRING_val.len, UTF8);
         yasm_dvs_append(dvs, dv);
         get_next_token(); /* STRING */
         num++;

--- a/modules/parsers/nasm/nasm-parser-struct.h
+++ b/modules/parsers/nasm/nasm-parser-struct.h
@@ -36,6 +36,7 @@ typedef union {
     uintptr_t arch_data;
     struct {
         char *contents;
+        yasm_utfenc enc;
         size_t len;
     } str;
 } nasm_yystype;

--- a/modules/parsers/nasm/nasm-parser.h
+++ b/modules/parsers/nasm/nasm-parser.h
@@ -39,6 +39,7 @@ enum tokentype {
     DIRECTIVE_NAME,
     FILENAME,
     STRING,
+    STRING_OP,
     SIZE_OVERRIDE,
     OFFSET,
     DECLARE_DATA,

--- a/modules/parsers/nasm/nasm-token.re
+++ b/modules/parsers/nasm/nasm-token.re
@@ -210,6 +210,26 @@ scan:
         }
 
         /* string/character constant values */
+        '__utf16__' | '__utf16le__' {
+            yasm_warn_set(YASM_WARN_GENERAL, N_("scan: UTF string ops aren't supported yet"));
+            lvalp->str.enc = UTF16LE;
+            RETURN(STRING_OP);
+        }
+        '__utf32__' | '__utf32le__' {
+            yasm_warn_set(YASM_WARN_GENERAL, N_("scan: UTF string ops aren't supported yet"));
+            lvalp->str.enc = UTF32LE;
+            RETURN(STRING_OP);
+        }
+        '__utf16be__' {
+            yasm_warn_set(YASM_WARN_GENERAL, N_("scan: UTF string ops aren't supported yet"));
+            lvalp->str.enc = UTF16BE;
+            RETURN(STRING_OP);
+        }
+        '__utf32be__' {
+            yasm_warn_set(YASM_WARN_GENERAL, N_("scan: UTF string ops aren't supported yet"));
+            lvalp->str.enc = UTF32BE;
+            RETURN(STRING_OP);
+        }
         quot {
             endch = s->tok[0];
             goto stringconst;


### PR DESCRIPTION
currently only in data value positions

- allows string literals to be wrapped in __utf{16,32}{,le,be}__(...)
- if not specified, encoding is in little-endian scheme

for reference: https://www.nasm.us/doc/nasmdoc3.html#section-3.4.5