### PR TITLE
Update elf-objfmt.c to support note.gnu.property note section

### DIFF
--- a/modules/objfmts/elf/elf-objfmt.c
+++ b/modules/objfmts/elf/elf-objfmt.c
@@ -1077,6 +1077,10 @@ elf_objfmt_section_switch(yasm_object *object, yasm_valparamhead *valparams,
         align = 0;
         data.type = SHT_PROGBITS;
         data.flags = 0;
+    } else if (strcmp(sectname, ".note.gnu.property") == 0) {
+        align = 8;
+        data.type = SHT_NOTE;
+        data.flags = 0;
     } else {
         /* Default to code */
         align = 1;


### PR DESCRIPTION
tl;dnr: add support for .note.gnu.property note sections.

ceph has a few optimized crc32 routines hand written in assembly in nasm/yasm format. (Nobody appears to have the stomach for rewriting them in another format.)  Fedora requires that libraries be CET enabled. IOW all .o comprising a shared library need a note.gnu.properties NOTE section with some magic bits that tell the linker that the .o was compiled with the appropriate options.

I can add such a note section, but without this change yasm will not set the correct section type and I have to resort to some dd magic to set the correct section type before linking all the .o files into the shlib.