### PR TITLE
Fix test failures

### DIFF
--- a/modules/arch/x86/tests/x86_test.sh
+++ b/modules/arch/x86/tests/x86_test.sh
@@ -1,3 +1,3 @@
 #! /bin/sh
-${srcdir}/out_test.sh x86_test modules/arch/x86/tests "x86 arch" "-f bin" ""
+${srcdir}/out_test.sh x86_test modules/arch/x86/tests "x86 arch" "-f bin -Wsegreg-in-64bit" ""
 exit $?


### PR DESCRIPTION
These were caused by the addition of the segreg-in-64bit warning.