### PR TITLE
Fix UB/crashes

### DIFF
--- a/modules/preprocs/gas/gas-preproc.c
+++ b/modules/preprocs/gas/gas-preproc.c
@@ -912,6 +912,9 @@ static void expand_macro(yasm_preproc_gas *pp, macro_entry *macro, const char *a
                         char *end = strstr(macro->params[j], "=");
                         int len = (end ? (size_t)(end - macro->params[j])
                                        : strlen(macro->params[j]));
+                        if (!tokval.t_charptr) {
+                            continue;
+                        }
                         if (!strncmp(tokval.t_charptr, macro->params[j], len)
                             && tokval.t_charptr[len] == '\0') {
                             /* now, find matching argument. */
@@ -932,6 +935,9 @@ static void expand_macro(yasm_preproc_gas *pp, macro_entry *macro, const char *a
                             memcpy(line + cursor - len, value, value_length);
                             pp->expr.string = work = line;
                             pp->expr.string_cursor += delta;
+                            if (pp->expr.symbol == tokval.t_charptr) {
+                                tokval.t_charptr = NULL;
+                            }
                             if (pp->expr.symbol) {
                                 yasm_xfree(pp->expr.symbol);
                                 pp->expr.symbol = NULL;


### PR DESCRIPTION
Sometimes you may encounter strange errors like:
```
libvgstr3412_x64_asm.s:4473: error: Unrecognized register name %ym
libvgstr3412_x64_asm.s:4473: error: expected ','
make[2]: *** [Makefile:576: libvgstr3412_la-libvgstr3412_x64_asm.lo] Error 1g
```

Valgrind shows:
```valgrind /tmp/yasm-1.3.0/yasm -e -p gnu -f elf64 -DPROC_TYPE_X64 -DELF libvgstr3412_x64_asm.s -DPIC -o xxxx
==8224== Memcheck, a memory error detector
==8224== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==8224== Using Valgrind-3.17.0 and LibVEX; rerun with -h for copyright info
==8224== Command: /tmp/yasm-1.3.0/yasm -e -p gnu -f elf64 -DPROC_TYPE_X64 -DELF libvgstr3412_x64_asm.s -DPIC -o xxxx
==8224==
==8224== Invalid read of size 1
==8224==    at 0x4846C70: strncmp (vg_replace_strmem.c:663)
==8224==    by 0x43125C: expand_macro (gas-preproc.c:915)
==8224==    by 0x43125C: process_line (gas-preproc.c:1174)
==8224==    by 0x4317A2: gas_preproc_get_line (gas-preproc.c:1336)
==8224==    by 0x402A13: do_preproc_only (yasm.c:323)
==8224==    by 0x402A13: main (yasm.c:724)
==8224==  Address 0x4fa7330 is 0 bytes inside a block of size 4 free'd
==8224==    at 0x48430E4: free (vg_replace_malloc.c:755)
==8224==    by 0x43151D: expand_macro (gas-preproc.c:936)
==8224==    by 0x43151D: process_line (gas-preproc.c:1174)
==8224==    by 0x4317A2: gas_preproc_get_line (gas-preproc.c:1336)
==8224==    by 0x402A13: do_preproc_only (yasm.c:323)
==8224==    by 0x402A13: main (yasm.c:724)
==8224==  Block was alloc'd at
==8224==    at 0x48456AF: realloc (vg_replace_malloc.c:1192)
==8224==    by 0x414887: def_xrealloc (xmalloc.c:101)
==8224==    by 0x42F1A7: gas_scan (gas-preproc.c:440)
==8224==    by 0x4311FF: expand_macro (gas-preproc.c:906)
==8224==    by 0x4311FF: process_line (gas-preproc.c:1174)
==8224==    by 0x4317A2: gas_preproc_get_line (gas-preproc.c:1336)
==8224==    by 0x402A13: do_preproc_only (yasm.c:323)
==8224==    by 0x402A13: main (yasm.c:724)
==8224==
==8224== Invalid read of size 1
==8224==    at 0x431268: expand_macro (gas-preproc.c:916)
==8224==    by 0x431268: process_line (gas-preproc.c:1174)
==8224==    by 0x4317A2: gas_preproc_get_line (gas-preproc.c:1336)
==8224==    by 0x402A13: do_preproc_only (yasm.c:323)
==8224==    by 0x402A13: main (yasm.c:724)
==8224==  Address 0x56c5581 is 1 bytes inside a block of size 13 free'd
==8224==    at 0x48430E4: free (vg_replace_malloc.c:755)
==8224==    by 0x43151D: expand_macro (gas-preproc.c:936)
==8224==    by 0x43151D: process_line (gas-preproc.c:1174)
==8224==    by 0x4317A2: gas_preproc_get_line (gas-preproc.c:1336)
==8224==    by 0x402A13: do_preproc_only (yasm.c:323)
==8224==    by 0x402A13: main (yasm.c:724)
==8224==  Block was alloc'd at
==8224==    at 0x48456AF: realloc (vg_replace_malloc.c:1192)
==8224==    by 0x414887: def_xrealloc (xmalloc.c:101)
==8224==    by 0x42F1A7: gas_scan (gas-preproc.c:440)
==8224==    by 0x4311FF: expand_macro (gas-preproc.c:906)
==8224==    by 0x4311FF: process_line (gas-preproc.c:1174)
==8224==    by 0x4317A2: gas_preproc_get_line (gas-preproc.c:1336)
==8224==    by 0x402A13: do_preproc_only (yasm.c:323)
==8224==    by 0x402A13: main (yasm.c:724)
```