### PR TITLE
Remove __DATE__ from version strings.

### DIFF
--- a/frontends/tasm/tasm.c
+++ b/frontends/tasm/tasm.c
@@ -228,7 +228,6 @@ static opt_option options[] =
 /* version message */
 /*@observer@*/ static const char *version_msg[] = {
     PACKAGE_STRING,
-    "Compiled on " __DATE__ ".",
     "Copyright (c) 2001-2010 Peter Johnson and other Yasm developers.",
     "Run yasm --license for licensing overview and summary."
 };

--- a/frontends/vsyasm/vsyasm.c
+++ b/frontends/vsyasm/vsyasm.c
@@ -220,7 +220,6 @@ static opt_option options[] =
 /* version message */
 /*@observer@*/ static const char *version_msg[] = {
     PACKAGE_STRING,
-    "Compiled on " __DATE__ ".",
     "Copyright (c) 2001-2010 Peter Johnson and other Yasm developers.",
     "Run yasm --license for licensing overview and summary."
 };

--- a/frontends/yasm/yasm.c
+++ b/frontends/yasm/yasm.c
@@ -219,7 +219,6 @@ static opt_option options[] =
 /* version message */
 /*@observer@*/ static const char *version_msg[] = {
     PACKAGE_STRING,
-    "Compiled on " __DATE__ ".",
     "Copyright (c) 2001-2014 Peter Johnson and other Yasm developers.",
     "Run yasm --license for licensing overview and summary."
 };


### PR DESCRIPTION
Having `__DATE__` in version strings is causing compilation errors when it's defined by Bazel build tool like this:

    -D__DATE__=redacted

Removing `__DATE__` helps also to achieve deterministic builds.