### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -51,6 +51,18 @@ The simplest way to compile this package is:
      all sorts of other programs in order to regenerate files that came
      with the distribution.
 
+Installation using vcpkg
+==================
+You can build and install yasm using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+   `git clone https://github.com/Microsoft/vcpkg.git'
+   `cd vcpkg'
+   `./bootstrap-vcpkg.sh'  # `./bootstrap-vcpkg.bat' for Windows
+   `./vcpkg integrate install'
+   `./vcpkg install yasm'
+
+The yasm port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 Compilers and Options
 =====================
 


### PR DESCRIPTION
Yasm is available as a port in vcpkg, a C++ library manager that simplifies installation for yasm and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build yasm, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/yasm/portfile.cmake). We try to keep the library maintained as close as possible to the original library.