### PR TITLE
Introduce a security policy and add text to the README

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,13 @@
+The Yasm Modular Assembler Project
+==================================
+
+Yasm is a complete rewrite of the NASM assembler under the “new” BSD License
+(some portions are under other licenses, see COPYING for details).
+
+Yasm currently supports the x86 and AMD64 instruction sets, accepts NASM and
+GAS assembler syntaxes, outputs binary, ELF32, ELF64, 32 and 64-bit Mach-O,
+RDOFF2, COFF, Win32, and Win64 object formats, and generates source debugging
+information in STABS, DWARF 2, and CodeView 8 formats.
+
+Yasm can be easily integrated into Visual Studio 2005/2008 and 2010 for
+assembly of NASM or GAS syntax code into Win32 or Win64 object files.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+Yasm Security policy
+====================
+
+A security bug is one that compromises the security of a system by either
+making it unavailable, compromising the integrity of the data or by providing
+unauthorized access to resources on the system through untrusted inputs.  In
+the context of yasm, it is expected that all inputs are trusted, since it is
+developer code.  It is the responsibility of the developer to either verify the
+authenticity of the code they're building or to build untrusted code in a
+sandbox to protect the system from any ill effects.  This responsibility also
+extends to the libyasm library.  While the library aims to be robust and will
+fix bugs arising from bogus inputs, it is the responsibility of the application
+to ensure that either the environment under which the call is made is isolated
+or that the input is sanitized.
+
+As such, all bugs will be deemed to have no security consequence with the
+exception of bugs where yasm generates code that invoke [undefined behaviour in
+a
+system](https://www.cs.cmu.edu/~rdriley/487/papers/Thompson_1984_ReflectionsonTrustingTrust.pdf)
+from valid, safe and trusted assembly code.
+
+Reporting security bugs
+-----------------------
+
+To report security issues privately, you may reach out to one of the members of
+the [Yasm Team](https://github.com/yasm/yasm/wiki/Yasmteam).  Most issues
+should just go into GitHub issues as regular bugs.


### PR DESCRIPTION
There has been a rash of bogus CVEs filed against yasm for fuzzed inputs lately that will never really happen in production unless users do things that are already considered unsafe, like attempting to build arbitrary inputs as code. The binutils project recently adopted a [security policy](https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=binutils/SECURITY.txt) that rejects all such fuzzed input CVEs, treating them as regular bugs.

This patchset proposes doing the same so that there's a stronger case for rejecting such CVEs outright. The patchset also adds text to the README, which is basically cribbed from the yasm website. One possible gap is that the Yasm team page does not have email addresses of any of the members, although I suppose they're easy to glean from the commit logs.