### PR TITLE
Fix missing yasm_xfree function declaration

### DIFF
--- a/libyasm/tests/bitvect_test.c
+++ b/libyasm/tests/bitvect_test.c
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "util.h"
 #include "libyasm/bitvect.h"
 
 static int


### PR DESCRIPTION

    This fixes the following compiler error in macOS in CI.

    libyasm/tests/bitvect_test.c:112:5: error: implicit declaration of
    function 'yasm_xfree' [-Werror,-Wimplicit-function-declaration]

