### PR TITLE
fix issue #210

### DIFF
--- a/modules/objfmts/bin/bin-objfmt.c
+++ b/modules/objfmts/bin/bin-objfmt.c
@@ -1680,6 +1680,10 @@ static void
 bin_section_data_destroy(void *data)
 {
     bin_section_data *bsd = (bin_section_data *)data;
+    if (bsd->align)
+        yasm_xfree(bsd->align);
+    if (bsd->valign)
+        yasm_xfree(bsd->valign);
     if (bsd->start)
         yasm_expr_destroy(bsd->start);
     if (bsd->vstart)


### PR DESCRIPTION
This is a fix for memory leak (issue #210).
Adding the fix, valgrind no longer reports the memory leaks in my environment (Ubuntu 20.04.3 LTS).
I would be happy if this PR is reviewed.