### PR TITLE
Fix access field adress on null pointer in x86bc.c

### DIFF
--- a/modules/arch/x86/x86bc.c
+++ b/modules/arch/x86/x86bc.c
@@ -654,7 +654,9 @@ x86_bc_insn_expand(yasm_bytecode *bc, int span, long old_val, long new_val,
 {
     x86_insn *insn = (x86_insn *)bc->contents;
     x86_effaddr *x86_ea = insn->x86_ea;
-    yasm_effaddr *ea = &x86_ea->ea;
+    yasm_effaddr *ea = NULL;
+    if (x86_ea != NULL)
+        ea = &x86_ea->ea;
     yasm_value *imm = insn->imm;
 
     if (ea && span == 1) {


### PR DESCRIPTION
Fix asan issue
``modules/arch/x86/x86bc.c:657:19: runtime error: member access within null pointer of type 'struct x86_effaddr'``

Sample asm code for trigger issue
```
push label
label:
```