### PR TITLE
Fix memory leak if masm mode enabled in parsers

### DIFF
--- a/modules/parsers/nasm/nasm-parse.c
+++ b/modules/parsers/nasm/nasm-parse.c
@@ -966,6 +966,7 @@ parse_operand(yasm_parser_nasm *parser_nasm)
             unsigned int size = SIZE_OVERRIDE_val;
             get_next_token();
             if (parser_nasm->masm && curtok == ID && !yasm__strcasecmp(ID_val, "ptr")) {
+                destroy_curtok();
                 get_next_token();
             }
             op = parse_operand(parser_nasm);


### PR DESCRIPTION
Fix memory leak if masm mode enabled in parsers.

Masm parsing mode can be enabled if change line in file ``modules/parsers/nasm/nasm-parser.c``

```
-    parser_nasm.masm = 0;
+    parser_nasm.masm = 1;
```

Minimal asm code sample
```
mov eax, dword ptr [100]
```
