### PR TITLE
Fix nullptr deref in yasm_expr__copy_except

### DIFF
--- a/libyasm/expr.c
+++ b/libyasm/expr.c
@@ -994,7 +994,10 @@ yasm_expr__copy_except(const yasm_expr *e, int except)
 {
     yasm_expr *n;
     int i;
-    
+
+    if (e == NULL)
+        return NULL;
+
     n = yasm_xmalloc(sizeof(yasm_expr) +
                      sizeof(yasm_expr__item)*(e->numterms<2?0:e->numterms-2));
 


### PR DESCRIPTION
In `yasm/modules/parsers/nasm/nasm-parse.c:1562`, the function `nasm_parser_directive` passes `parser_nasm->absstart` to `yasm_expr_copy`. However, the return value of `yasm_vp_expr` may be null, and `yasm_expr_copy` does not check for it.
```c
parser_nasm->absstart = yasm_vp_expr(vp, p_object->symtab, line);
parser_nasm->abspos = yasm_expr_copy(parser_nasm->absstart);
```
Here is a PoC to trigger it:
```
echo ZGIgaO4QAHhdCmwAgAAAXQpsYWJlbDE3ClthYjE6ClthYnNvbHV0ZSdsYWJlbDFdCng6 | base64 -d > poc.asm
./yasm poc.asm
```