### PR TITLE
Fix use-after-free in yasm_intnum_destroy

### DIFF
--- a/libyasm/expr.c
+++ b/libyasm/expr.c
@@ -687,6 +687,7 @@ expr_level_op(/*@returned@*/ /*@only@*/ yasm_expr *e, int fold_const,
                 level_numterms--;
                 /* make sure to delete folded intnum */
                 yasm_intnum_destroy(e->terms[i].data.intn);
+                e->terms[i].data.intn = NULL;
             } else if (o != i) {
                 /* copy term if it changed places */
                 e->terms[o++] = e->terms[i];

--- a/libyasm/intnum.c
+++ b/libyasm/intnum.c
@@ -412,6 +412,8 @@ yasm_intnum_copy(const yasm_intnum *intn)
 void
 yasm_intnum_destroy(yasm_intnum *intn)
 {
+    if (intn == NULL)
+        return;
     if (intn->type == INTNUM_BV)
         BitVector_Destroy(intn->val.bv);
     yasm_xfree(intn);


### PR DESCRIPTION
I found a UAF bug in `yasm_intnum_destroy`, the PoC is
```
echo bTUYdGltZXMgKCQkLSQpICYoJCUtJCkgJiAxRmggbm9wIDsgTHdvcmQgYQAB | base64 -d > poc.asm
./yasm poc.asm
```
The root cause located at `expr_level_op`, line 689 freed the `intn`, however in `expr_simplify_identity` will free the `intn` again.
```c
for (i=first_int_term+1, o=first_int_term+1; i<e->numterms; i++) {
    if (e->terms[i].type == YASM_EXPR_INT) {
        yasm_intnum_calc(e->terms[first_int_term].data.intn, e->op,
                         e->terms[i].data.intn);
        fold_numterms--;
        level_numterms--;
        /* make sure to delete folded intnum */
        yasm_intnum_destroy(e->terms[i].data.intn); // free location
    } else if (o != i) {
        /* copy term if it changed places */
        e->terms[o++] = e->terms[i];
    } else
        o++;
}

if (simplify_ident) {
    int new_fold_numterms;
    /* Simplify identities and make IDENT if possible. */
    new_fold_numterms =
        expr_simplify_identity(e, fold_numterms, &first_int_term,
                               simplify_reg_mul); // call `yasm_intnum_destroy` again with same argument
    level_numterms -= fold_numterms-new_fold_numterms;
    fold_numterms = new_fold_numterms;
}
```
attach the ASAN report
```
=================================================================
==1274964==ERROR: AddressSanitizer: heap-use-after-free on address 0x6020000070f8 at pc 0x00000052fc14 bp 0x7fff6fbf0a70 sp 0x7fff6fbf0a68
READ of size 4 at 0x6020000070f8 thread T0
    #0 0x52fc13 in yasm_intnum_destroy /home/moe/UAFTest/yasm/libyasm/intnum.c:415:15
    #1 0x622fa8 in expr_delete_term /home/moe/UAFTest/yasm/libyasm/expr.c:1017:13
    #2 0x622fa8 in expr_simplify_identity /home/moe/UAFTest/yasm/libyasm/expr.c:582:17
    #3 0x61ae4b in expr_level_op /home/moe/UAFTest/yasm/libyasm/expr.c:701:17
    #4 0x61d6c2 in expr_level_tree /home/moe/UAFTest/yasm/libyasm/expr.c:880:9
    #5 0x61fbbe in yasm_expr__level_tree /home/moe/UAFTest/yasm/libyasm/expr.c:906:9
    #6 0x61fbbe in yasm_expr_get_intnum /home/moe/UAFTest/yasm/libyasm/expr.c:1261:11
    #7 0x53c211 in recalc_normal_span /home/moe/UAFTest/yasm/libyasm/section.c:1044:15
    #8 0x538887 in yasm_object_optimize /home/moe/UAFTest/yasm/libyasm/section.c:1392:20
    #9 0x4d20c7 in do_assemble /home/moe/UAFTest/yasm/frontends/yasm/yasm.c:651:5
    #10 0x4d20c7 in main /home/moe/UAFTest/yasm/frontends/yasm/yasm.c:877:12
    #11 0x7fda56527d8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #12 0x7fda56527e3f in __libc_start_main csu/../csu/libc-start.c:392:3
    #13 0x420454 in _start (/home/moe/UAFTest/yasm/yasm+0x420454)

0x6020000070f8 is located 8 bytes inside of 16-byte region [0x6020000070f0,0x602000007100)
freed by thread T0 here:
    #0 0x49d0d2 in free (/home/moe/UAFTest/yasm/yasm+0x49d0d2)
    #1 0x61ac51 in expr_level_op /home/moe/UAFTest/yasm/libyasm/expr.c:689:17
    #2 0x61d6c2 in expr_level_tree /home/moe/UAFTest/yasm/libyasm/expr.c:880:9
    #3 0x61fbbe in yasm_expr__level_tree /home/moe/UAFTest/yasm/libyasm/expr.c:906:9
    #4 0x61fbbe in yasm_expr_get_intnum /home/moe/UAFTest/yasm/libyasm/expr.c:1261:11
    #5 0x53c211 in recalc_normal_span /home/moe/UAFTest/yasm/libyasm/section.c:1044:15
    #6 0x538887 in yasm_object_optimize /home/moe/UAFTest/yasm/libyasm/section.c:1392:20
    #7 0x4d20c7 in do_assemble /home/moe/UAFTest/yasm/frontends/yasm/yasm.c:651:5
    #8 0x4d20c7 in main /home/moe/UAFTest/yasm/frontends/yasm/yasm.c:877:12
    #9 0x7fda56527d8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16

previously allocated by thread T0 here:
    #0 0x49d33d in __interceptor_malloc (/home/moe/UAFTest/yasm/yasm+0x49d33d)
    #1 0x549d10 in def_xmalloc /home/moe/UAFTest/yasm/libyasm/xmalloc.c:69:14
    #2 0x52f9df in yasm_intnum_copy /home/moe/UAFTest/yasm/libyasm/intnum.c:397:22
    #3 0x61e089 in expr_item_copy /home/moe/UAFTest/yasm/libyasm/expr.c:975:31
    #4 0x61ddc1 in yasm_expr__copy_except /home/moe/UAFTest/yasm/libyasm/expr.c:1006:13
    #5 0x53c001 in recalc_normal_span /home/moe/UAFTest/yasm/libyasm/section.c:1035:31
    #6 0x538887 in yasm_object_optimize /home/moe/UAFTest/yasm/libyasm/section.c:1392:20
    #7 0x4d20c7 in do_assemble /home/moe/UAFTest/yasm/frontends/yasm/yasm.c:651:5
    #8 0x4d20c7 in main /home/moe/UAFTest/yasm/frontends/yasm/yasm.c:877:12
    #9 0x7fda56527d8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16

SUMMARY: AddressSanitizer: heap-use-after-free /home/moe/UAFTest/yasm/libyasm/intnum.c:415:15 in yasm_intnum_destroy
Shadow bytes around the buggy address:
  0x0c047fff8dc0: fa fa fd fa fa fa 03 fa fa fa 00 00 fa fa 03 fa
  0x0c047fff8dd0: fa fa 00 00 fa fa 02 fa fa fa 00 00 fa fa 02 fa
  0x0c047fff8de0: fa fa 00 00 fa fa 02 fa fa fa 00 00 fa fa 00 00
  0x0c047fff8df0: fa fa 00 00 fa fa 00 00 fa fa fd fd fa fa fd fd
  0x0c047fff8e00: fa fa fd fd fa fa 00 00 fa fa 00 00 fa fa fd fd
=>0x0c047fff8e10: fa fa 00 00 fa fa 00 00 fa fa fd fd fa fa fd[fd]
  0x0c047fff8e20: fa fa 00 00 fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff8e30: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff8e40: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff8e50: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff8e60: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==1274964==ABORTING
```