### PR TITLE
Fix handle_dot_label heap-out-of-bound

### DIFF
--- a/modules/parsers/nasm/nasm-token.re
+++ b/modules/parsers/nasm/nasm-token.re
@@ -79,7 +79,7 @@ handle_dot_label(YYSTYPE *lvalp, char *tok, size_t toklen, size_t zeropos,
         lvalp->str_val = yasm__xstrndup(tok+zeropos+(parser_nasm->tasm?2:0),
             toklen-zeropos-(parser_nasm->tasm?2:0));
         /* check for special non-local ..@label */
-        if (lvalp->str_val[zeropos+2] == '@')
+        if (lvalp->str_val[2] == '@')
             return NONLOCAL_ID;
         return SPECIAL_ID;
     }


### PR DESCRIPTION
In the current implementation, there is a possible heap-out-of-bound error. It appears that the variable zeropos is used to index the array tok, but it should not be present in the str_val. This seems to be a typo, and I suggest either replacing it with tok[zeropos+2] or str_val[2].