### PR TITLE
Fix memory leak in nasm-pp.c

### DIFF
--- a/modules/preprocs/nasm/nasm-pp.c
+++ b/modules/preprocs/nasm/nasm-pp.c
@@ -3099,6 +3099,7 @@ do_directive(Token * tline)
             {
                 error(ERR_NONFATAL, "`%s': not defining a macro",
                         tline->text);
+                free_tlist(origline);
                 return DIRECTIVE_FOUND;
             }
             k = hash(defining->name);
@@ -3196,6 +3197,7 @@ do_directive(Token * tline)
                 {
                     error(ERR_NONFATAL, "non-constant value given to `%%rep'");
                     yasm_expr_destroy(evalresult);
+                    free_tlist(origline);
                     return DIRECTIVE_FOUND;
                 }
                 i = (int)yasm_intnum_get_int(intn) + 1;


### PR DESCRIPTION
Hi, I am a new contributor to this repository :). I came across the open issue #257  which is a leaksanitizer report about a leak that happens on  `./yasm -w poc` where input file poc is : https://github.com/hanxuer/crashes/blob/main/yasm/04/poc. 

I was able to reproduce the bug on running the command and was able to generate a patch for it. The leak happens within function `do_directive`  where `origline` is not freed before returning in 2 different places. The function `do_directive` enforces that it must free memory instead of it's callees.

I have verified that after the patch, the leak no longer occurs through leaksanitizer (and there is no double free for that matter).

Please let me know if the patch is useful :)