### PR TITLE
Fix memory leak in nasm-parse.c

### DIFF
--- a/modules/parsers/nasm/nasm-parse.c
+++ b/modules/parsers/nasm/nasm-parse.c
@@ -666,8 +666,10 @@ dv_done:
                 if (is_eol())   /* allow trailing , on list */
                     break;
             }
-            return yasm_bc_create_data(&dvs, size, 0, p_object->arch,
+            yasm_bytecode * retbc = yasm_bc_create_data(&dvs, size, 0, p_object->arch,
                                        cur_line);
+            yasm_dvs_delete(&dvs);
+            return retbc;
         }
         case RESERVE_SPACE:
         {


### PR DESCRIPTION
This is in response to issue #246 
There is a memory leak upon running `./yasm poc` where poc is input file: https://github.com/TimChan2001/pocs/raw/main/poc-yasm-1

I was able to reproduce the issue by executing the same command. The leak occurs because the function `parse_exp` returns without freeing `dvs` which was allocated earlier. Therefore as a patch I am freeing `dvs` and returning with the intermediate variable. 

I also found that all other locations where `yasm_bc_create_data` was called the first argument `dvs` was from stack and hence needn't be freed after return.

Please let me know if this patch is helpful :)