### PR TITLE
Fix buffer size check in cpp-preproc.c when reading lines with fgets

### DIFF
--- a/modules/preprocs/cpp/cpp-preproc.c
+++ b/modules/preprocs/cpp/cpp-preproc.c
@@ -265,7 +265,7 @@ cpp_preproc_get_line(yasm_preproc *preproc)
         p += strlen(p);
         if (p > buf && p[-1] == '\n')
             break;
-        if ((p-buf) >= bufsize) {
+        if ((p-buf) + 1 >= bufsize) {
             /* Increase size of buffer */
             char *oldbuf = buf;
             bufsize *= 2;


### PR DESCRIPTION
fgets reads at most bufsize-1 chars, the check for the full buffer has to account for the trailing NULL char. This code matches line reading code of gas-preproc.c