### PR TITLE
bitvect: fix build with gcc-15

### DIFF
--- a/libyasm/bitvect.h
+++ b/libyasm/bitvect.h
@@ -83,7 +83,11 @@ typedef  Z_longword         *Z_longwordptr;
     #ifdef MACOS_TRADITIONAL
         #define boolean Boolean
     #else
-        typedef enum boolean { false = FALSE, true = TRUE } boolean;
+        #if __STDC_VERSION__ < 202311L
+             typedef enum boolean { false = FALSE, true = TRUE } boolean;
+        #else
+             typedef bool boolean;
+        #endif
     #endif
 #endif
 


### PR DESCRIPTION
Fixes:
https://github.com/yasm/yasm/issues/283

```
libyasm/bitvect.h:86:32: error: cannot use keyword 'false' as enumeration constant
   86 |         typedef enum boolean { false = FALSE, true = TRUE } boolean;
      |                                ^~~~~
libyasm/bitvect.h:86:32: note: 'false' is a keyword with '-std=c23' onwards
```

as suggested in:
https://github.com/yasm/yasm/issues/283#issuecomment-2661108816

