### PR TITLE
dwarf2: Correctly initialize dwarf2_line_info.errwarns

### DIFF
--- a/modules/dbgfmts/dwarf2/dwarf2-line.c
+++ b/modules/dbgfmts/dwarf2/dwarf2-line.c
@@ -709,6 +709,7 @@ yasm_dwarf2__generate_line(yasm_object *object, yasm_linemap *linemap,
     info.dbgfmt_dwarf2 = dbgfmt_dwarf2;
     info.debug_line = yasm_object_get_general(object, ".debug_line", 1, 0, 0,
                                               &new, 0);
+    info.errwarns = errwarns;
 
     /* header */
     head = yasm_dwarf2__add_head(dbgfmt_dwarf2, info.debug_line, NULL, 0, 0);


### PR DESCRIPTION
Forgetting to this causes unexpected control flow transfers and even misoptimizations. When building with LLVM 20.1.4 and LTO enabled, misoptimizations will ultimately lead to segfaults in dwarf2_gen64_test.sh.