### PR TITLE
Fix null-pointer-dereference in hash

### DIFF
--- a/modules/preprocs/nasm/nasm-pp.c
+++ b/modules/preprocs/nasm/nasm-pp.c
@@ -1102,6 +1102,10 @@ hash(char *s)
 {
     unsigned int h = 0;
     unsigned int i = 0;
+    /* Check if the input string is NULL to avoid null pointer dereference */
+    if (s == NULL) {
+        return 0;
+    }
     /*
      * Powers of three, mod 31.
      */


### PR DESCRIPTION
A potential null pointer difference is that the return value of the hash may be null.
This issue is assigned CVE-2021-33456.
#175 