### PR TITLE
Build CMake project on ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,15 @@ jobs:
             os: macos-latest
             artifact: true
             autotools: true
+            cmake: true
           - name: Ubuntu
             os: ubuntu-latest
             artifact: true
             autotools: true
+            cmake: true
+          - name: MSVC
+            os: windows-latest
+            cmake: true
 
     name: "Build - ${{ matrix.name }}"
     runs-on: ${{ matrix.os }}
@@ -43,6 +48,13 @@ jobs:
         id: make-dist
         if: ${{ matrix.autotools }}
         run: make dist
+
+      - name: Configure (CMake)
+        if: ${{ matrix.cmake }}
+        run: cmake -S . -B build
+      - name: Build (CMake)
+        if: ${{ matrix.cmake }}
+        run: cmake --build build
 
       - uses: actions/upload-artifact@v7
         if: ${{ matrix.artifact && always() && steps.make-dist.outcome == 'success' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,32 +10,43 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
-            artifact-name: macOS
-          - os: ubuntu-latest
-            artifact-name: Ubuntu
+          - name: macOS
+            os: macos-latest
+            artifact: true
+            autotools: true
+          - name: Ubuntu
+            os: ubuntu-latest
+            artifact: true
+            autotools: true
 
-    name: "Build - ${{ matrix.artifact-name }}"
+    name: "Build - ${{ matrix.name }}"
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Install autotools
+        if: ${{ matrix.autotools }}
         run: |
           if [ "$RUNNER_OS" == "macOS" ]; then
             brew update
             brew install automake autoconf
           fi
-      - name: Autotools
+      - name: Autogen (autotools)
+        if: ${{ matrix.autotools }}
         run: ./autogen.sh
-      - name: Build
+      - name: Build (autotools)
+        if: ${{ matrix.autotools }}
         run: make
-      - name: Check
+      - name: Check (autotools)
+        if: ${{ matrix.autotools }}
         run: make check
-      - name: Dist
+      - name: Dist (autotools)
+        id: make-dist
+        if: ${{ matrix.autotools }}
         run: make dist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v7
+        if: ${{ matrix.artifact && always() && steps.make-dist.outcome == 'success' }}
         with:
-          name: ${{ matrix.artifact-name }}
+          name: ${{ matrix.name }}
           path: yasm-*.tar.gz
 


### PR DESCRIPTION
Hey yasm developers,

This PR builds yasm using the CMake build scripts.

motive:
The motive for this patch is the failure to build yasm with a recent CMake version.
It does not fail on Ubuntu (currently) because its CMake version is lagging behind. lags behind.

I'm willing to update the CMake to be compatible with CMake versions >= 3.5,
and also support building/running the unit tests if a developer with merge capability
is willing to review my patches in a timely manner.

The already-existing CMake PR's (https://github.com/yasm/yasm/pull/286 and https://github.com/yasm/yasm/pull/294) are addressing the CMake compatibility, but do not address the checks.


Output of a ci run:
https://github.com/madebr/yasm/actions/runs/27537918380