### PR TITLE
bool is a C keyword from C23 onwards

### DIFF
--- a/libyasm/bitvect.h
+++ b/libyasm/bitvect.h
@@ -82,6 +82,9 @@ typedef  Z_longword         *Z_longwordptr;
 #else
     #ifdef MACOS_TRADITIONAL
         #define boolean Boolean
+    #elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+        #include <stdbool.h>
+        typedef bool boolean;
     #else
         typedef enum boolean { false = FALSE, true = TRUE } boolean;
     #endif


### PR DESCRIPTION
This fixes the following error:
> In file included from frontends/yasm/yasm.c:31:
> ./libyasm/bitvect.h:86:32: error: cannot use keyword ‘false’ as enumeration constant
>    86 |         typedef enum boolean { false = FALSE, true = TRUE } boolean;
>       |                                ^~~~~
> ./libyasm/bitvect.h:86:32: note: ‘false’ is a keyword with ‘-std=c23’ onwards