### PR TITLE
cmake: register all modules in yasm_init_plugin

### DIFF
--- a/modules/objfmts/bin/CMakeLists.txt
+++ b/modules/objfmts/bin/CMakeLists.txt
@@ -1,3 +1,6 @@
 YASM_ADD_MODULE(objfmt_bin
     objfmts/bin/bin-objfmt.c
     )
+
+YASM_ADD_MODULE(objfmt_dosexe
+    )

--- a/modules/parsers/gas/CMakeLists.txt
+++ b/modules/parsers/gas/CMakeLists.txt
@@ -10,3 +10,6 @@ YASM_ADD_MODULE(parser_gas
     parsers/gas/gas-parse-intel.c
     gas-token.c
     )
+
+YASM_ADD_MODULE(parser_gnu
+    )

--- a/modules/parsers/nasm/CMakeLists.txt
+++ b/modules/parsers/nasm/CMakeLists.txt
@@ -19,3 +19,6 @@ YASM_ADD_MODULE(parser_nasm
     parsers/nasm/nasm-parse.c
     nasm-token.c
     )
+
+YASM_ADD_MODULE(parser_tasm
+    )

--- a/modules/preprocs/nasm/CMakeLists.txt
+++ b/modules/preprocs/nasm/CMakeLists.txt
@@ -23,3 +23,5 @@ YASM_ADD_MODULE(preproc_nasm
     preprocs/nasm/nasm-eval.c
     )
 
+YASM_ADD_MODULE(preproc_tasm
+    )


### PR DESCRIPTION
Some modules were not registered when dynamically loading yasmstd.