### PR TITLE
Don't output absolute output path in binfmt mapfile

### DIFF
--- a/modules/objfmts/bin/bin-objfmt.c
+++ b/modules/objfmts/bin/bin-objfmt.c
@@ -30,6 +30,7 @@
 #include <unistd.h>
 #endif
 #include <libyasm.h>
+#include <string.h>
 
 
 #define REGULAR_OUTBUF_SIZE     1024
@@ -778,7 +779,15 @@ output_map(bin_objfmt_output_info *info)
     for (i=0; i<63; i++)
         fputc('-', f);
     fprintf(f, "\n\nSource file:  %s\n", info->object->src_filename);
-    fprintf(f, "Output file:  %s\n\n", info->object->obj_filename);
+    if (getenv("YASM_TEST_SUITE")) {
+        const char *filename = info->object->obj_filename;
+        const char *next_filename;
+        while ((next_filename = strpbrk(filename, "/\\")))
+            filename = next_filename + 1;
+        fprintf(f, "Output file:  %s\n\n", filename);
+    } else {
+        fprintf(f, "Output file:  %s\n\n", info->object->obj_filename);
+    }
 
     fprintf(f, "-- Program origin ");
     for (i=0; i<61; i++)

--- a/modules/objfmts/bin/tests/multisect/bin-align.map
+++ b/modules/objfmts/bin/tests/multisect/bin-align.map
@@ -2,7 +2,7 @@
 - YASM Map file ---------------------------------------------------------------
 
 Source file:  -
-Output file:  results/bin-align
+Output file:  bin-align
 
 -- Program origin -------------------------------------------------------------
 

--- a/modules/objfmts/bin/tests/multisect/bin-ssym.map
+++ b/modules/objfmts/bin/tests/multisect/bin-ssym.map
@@ -2,7 +2,7 @@
 - YASM Map file ---------------------------------------------------------------
 
 Source file:  -
-Output file:  results/bin-ssym
+Output file:  bin-ssym
 
 -- Program origin -------------------------------------------------------------
 

--- a/modules/objfmts/bin/tests/multisect/initbss.map
+++ b/modules/objfmts/bin/tests/multisect/initbss.map
@@ -2,7 +2,7 @@
 - YASM Map file ---------------------------------------------------------------
 
 Source file:  -
-Output file:  results/initbss
+Output file:  initbss
 
 -- Program origin -------------------------------------------------------------
 

--- a/modules/objfmts/bin/tests/multisect/ldlinux-sects.map
+++ b/modules/objfmts/bin/tests/multisect/ldlinux-sects.map
@@ -2,7 +2,7 @@
 - YASM Map file ---------------------------------------------------------------
 
 Source file:  -
-Output file:  results/ldlinux-sects
+Output file:  ldlinux-sects
 
 -- Program origin -------------------------------------------------------------
 

--- a/modules/objfmts/bin/tests/multisect/multisect1.map
+++ b/modules/objfmts/bin/tests/multisect/multisect1.map
@@ -2,7 +2,7 @@
 - YASM Map file ---------------------------------------------------------------
 
 Source file:  -
-Output file:  results/multisect1
+Output file:  multisect1
 
 -- Program origin -------------------------------------------------------------
 

--- a/modules/objfmts/bin/tests/multisect/multisect2.map
+++ b/modules/objfmts/bin/tests/multisect/multisect2.map
@@ -2,7 +2,7 @@
 - YASM Map file ---------------------------------------------------------------
 
 Source file:  -
-Output file:  results/multisect2
+Output file:  multisect2
 
 -- Program origin -------------------------------------------------------------
 

--- a/modules/objfmts/bin/tests/multisect/multisect3.map
+++ b/modules/objfmts/bin/tests/multisect/multisect3.map
@@ -2,7 +2,7 @@
 - YASM Map file ---------------------------------------------------------------
 
 Source file:  -
-Output file:  results/multisect3
+Output file:  multisect3
 
 -- Program origin -------------------------------------------------------------
 

--- a/modules/objfmts/bin/tests/multisect/multisect4.map
+++ b/modules/objfmts/bin/tests/multisect/multisect4.map
@@ -2,7 +2,7 @@
 - YASM Map file ---------------------------------------------------------------
 
 Source file:  -
-Output file:  results/multisect4
+Output file:  multisect4
 
 -- Program origin -------------------------------------------------------------
 

--- a/modules/objfmts/bin/tests/multisect/multisect5.map
+++ b/modules/objfmts/bin/tests/multisect/multisect5.map
@@ -2,7 +2,7 @@
 - YASM Map file ---------------------------------------------------------------
 
 Source file:  -
-Output file:  results/multisect5
+Output file:  multisect5
 
 -- Program origin -------------------------------------------------------------
 

--- a/modules/objfmts/bin/tests/multisect/nomultisect1.map
+++ b/modules/objfmts/bin/tests/multisect/nomultisect1.map
@@ -2,7 +2,7 @@
 - YASM Map file ---------------------------------------------------------------
 
 Source file:  -
-Output file:  results/nomultisect1
+Output file:  nomultisect1
 
 -- Program origin -------------------------------------------------------------
 

--- a/modules/objfmts/bin/tests/multisect/nomultisect2.map
+++ b/modules/objfmts/bin/tests/multisect/nomultisect2.map
@@ -2,7 +2,7 @@
 - YASM Map file ---------------------------------------------------------------
 
 Source file:  -
-Output file:  results/nomultisect2
+Output file:  nomultisect2
 
 -- Program origin -------------------------------------------------------------
 

--- a/modules/parsers/nasm/tests/worphan/orphanwarn.errwarn
+++ b/modules/parsers/nasm/tests/worphan/orphanwarn.errwarn
@@ -1,2 +1,2 @@
--:2: warning: label alone on aline without a colon might be in error
--:3: warning: label alone on aline without a colon might be in error
+-:2: warning: label alone on a line without a colon might be in error
+-:3: warning: label alone on a line without a colon might be in error


### PR DESCRIPTION
Avoiding to put an absolute path in the output allows running the tests from any location (e.g. from a build directory)


Long term, yasm should probably get a `--reproducible` argument that avoids adding any absolute paths to the output